### PR TITLE
Added an example for accessing a resource from a fixture in a package

### DIFF
--- a/src/test-dummies/resources/resources/test/demo.css
+++ b/src/test-dummies/resources/resources/test/demo.css
@@ -1,0 +1,1 @@
+/* Here is a CSS file (Used by Resources test) */

--- a/src/test/java/spec/concordion/annotation/ResourcesTest.java
+++ b/src/test/java/spec/concordion/annotation/ResourcesTest.java
@@ -2,11 +2,9 @@ package spec.concordion.annotation;
 
 import java.io.File;
 import java.net.URISyntaxException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import org.concordion.api.Resource;
 import org.concordion.api.Element;
+import org.concordion.api.Resource;
 import org.concordion.integration.junit4.ConcordionRunner;
 import org.junit.runner.RunWith;
 
@@ -16,9 +14,8 @@ import test.concordion.TestRig;
 
 @RunWith(ConcordionRunner.class)
 public class ResourcesTest {
-	private TestRig testRig = null;
+    private TestRig testRig = null;
 	private JavaSourceCompiler compiler;
-	private static final Pattern CLASS_NAME_PATTERN = Pattern.compile("class\\s*(.*?)\\s*(\\{|extends)");
 	private ProcessingResult result;
 	
     public void process(String javaFragment) throws Exception {
@@ -48,11 +45,11 @@ public class ResourcesTest {
     }
     
     private Object compile(String javaSource) throws Exception, InstantiationException, IllegalAccessException {
-    	return compiler.compile(getClassName(javaSource), javaSource).newInstance();
+        return compiler.compile(javaSource).newInstance();
 	}
     
     private Object compile(String javaSource, String javaSourceParent) throws Exception, InstantiationException, IllegalAccessException {
-    	return compiler.compile(getClassName(javaSource), javaSource, getClassName(javaSourceParent), javaSourceParent).newInstance();
+        return compiler.compileWithParent(javaSource, javaSourceParent).newInstance();
 	}
 
 	private ProcessingResult process(String htmlFragment, Object fixture) {
@@ -62,32 +59,12 @@ public class ResourcesTest {
             .withResource(new Resource("/demo.css"), "")
             .withResource(new Resource("/spec/demo.js"), "")
             .withResource(new Resource("/spec/demo.txt"), "")
+            .withResource(new Resource("/resources/test/demo.css"), "")
             .processFragment(htmlFragment);
         
         return result;
     }
 	
-    private String getClassName(String javaFragment) {
-        Matcher matcher = CLASS_NAME_PATTERN.matcher(javaFragment);
-        matcher.find();
-        
-        return matcher.group(1);
-    }
-    
-//    private String getPackageName(String javaFragment) {
-//    	Matcher matcher = Pattern.compile("(?m)^package\\s*(.*);$").matcher(javaFragment);
-//        //Matcher matcher = PACKAGE_NAME_PATTERN.matcher(javaFragment);
-//        matcher.find();
-//        
-//        String packageName = matcher.group(1);
-//        
-//        if (!packageName.isEmpty()) {
-//        	packageName += ".";
-//        }
-//        
-//        return packageName;
-//    }
-    
     public String getLink(String expectedResource) {
     	Element[] links = result.getRootElement().getFirstChildElement("head").getChildElements("link");
     	

--- a/src/test/java/test/concordion/JavaSourceCompiler.java
+++ b/src/test/java/test/concordion/JavaSourceCompiler.java
@@ -1,16 +1,26 @@
 package test.concordion;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import test.concordion.compiler.CompilationFailedException;
 import test.concordion.compiler.Source;
 
 public class JavaSourceCompiler {
 
+    private static final Pattern CLASS_NAME_PATTERN = Pattern.compile("class\\s*(.*?)\\s*(\\{|extends)");
+    private static final Pattern PACKAGE_NAME_PATTERN = Pattern.compile("(?m)^package\\s*(.*);$");
     private test.concordion.compiler.JavaCompiler compiler = new test.concordion.compiler.JavaCompiler();
-    
+
+    public Class<?> compile(String sourceCode) throws Exception {
+        String qualifiedClassName = getPackageName(sourceCode) + getClassName(sourceCode);
+        return compile(qualifiedClassName, sourceCode);
+    }
+
     public Class<?> compile(String className, String sourceCode) throws Exception {
         
         try {
-            compiler.compile(new Source(sourceCode, className + ".java"));
+            compiler.compile(new Source(sourceCode, className.replaceAll("\\.", "/") + ".java"));
         } catch (CompilationFailedException e) {
             e.printDiagnosticsTo(System.out);
         }
@@ -18,8 +28,13 @@ public class JavaSourceCompiler {
         return compiler.forName(className);
     }
     
+    public Class<?> compileWithParent(String sourceCode, String sourceCodeParent) throws Exception {
+        String qualifiedClassName = getPackageName(sourceCode) + getClassName(sourceCode);
+        String qualifiedParentClassName = getPackageName(sourceCodeParent) + getClassName(sourceCodeParent);
+        return compile(qualifiedClassName, sourceCode, qualifiedParentClassName, sourceCodeParent);
+    }
+
     public Class<?> compile(String className, String sourceCode, String classNameParent, String sourceCodeParent) throws Exception {
-        
     	try {
             compiler.compile(new Source(sourceCode, className + ".java"), new Source(sourceCodeParent, classNameParent + ".java"));
         } catch (CompilationFailedException e) {
@@ -29,4 +44,25 @@ public class JavaSourceCompiler {
         return compiler.forName(className);
     }
 
+    private String getClassName(String javaFragment) {
+        Matcher matcher = CLASS_NAME_PATTERN.matcher(javaFragment);
+        matcher.find();
+
+        return matcher.group(1);
+    }
+
+    private String getPackageName(String javaFragment) {
+        Matcher matcher = PACKAGE_NAME_PATTERN.matcher(javaFragment);
+        if (!matcher.find()) {
+            return "";
+        }
+
+        String packageName = matcher.group(1);
+
+        if (!packageName.isEmpty()) {
+            packageName += ".";
+        }
+
+        return packageName;
+    }
 }

--- a/src/test/resources/spec/concordion/annotation/Resources.html
+++ b/src/test/resources/spec/concordion/annotation/Resources.html
@@ -18,6 +18,9 @@
 
     <h1>Resources Annotation</h1>
 
+    <dl><dt><b>Since:</b></dt>
+    <dd>Concordion 2.0.0</dd></dl>
+
     <p>
         The Resources annotation can be used to apply a new theme to your specifications, tweak the existing styling, or add 
         new css, javascript, images, or other resources.
@@ -213,6 +216,30 @@ public class ResourcesDemoParent {
     		and will copy the resource <span concordion:assertTrue="isCopied(#TEXT)">spec/demo.txt</span>,
     	</p>
     </div> 
+    <!-- ============================================= -->
+    <div class="example">
+        <h3>Example: Relative resource with fixture class in a package</h3>
+
+        <p>Executing the following fixture:</p>
+
+        <pre class="java" concordion:set="#javaFragment">
+package resources.test;
+
+import org.concordion.api.Resources;
+import org.concordion.api.Resources.InsertType;
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(ConcordionRunner.class)
+@Resources( value = "demo.css" )
+public class ResourcesDemoTest {
+
+}
+        </pre>
+
+        <p concordion:execute="#result1 = process(#javaFragment)">will include a link to the resource <span concordion:assertEquals="getLink(#TEXT)">demo.css</span>.
+        </p>
+    </div>
 
 </body>
 </html>


### PR DESCRIPTION
A basic example with the fixture class in a (non-default) package. You had most of the code there already!

I think we'll need some other examples.

One question I'd have is, when a relative resource is declared in a parent class that is in a different package to the fixture class, is the resource relative to the parent class location, or the fixture class location. Eg. parent class is in `resources` package, fixture class is in `resources.test` package, parent class declares `@Resources("demo.css")`. Does it pick up `resources/demo.css` or `resources/test/demo.css`?